### PR TITLE
Added support for VIAs

### DIFF
--- a/eagle.FCMacro
+++ b/eagle.FCMacro
@@ -16,7 +16,7 @@ import string
 
 
 eagle_dimension_layer = 20
-setting_cut_holes = True
+setting_cut_holes = False
 
 
 try:


### PR DESCRIPTION
I have added support for the standalone vias which does not belong to a part, but belongs to a signal. 
I have left the drilling option off.
